### PR TITLE
docs: 修复 wrangler kv 命令语法适配 v3+

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -97,7 +97,7 @@ wrangler secret put FEISHU_APP_SECRET
 wrangler secret put COOKIE_ENCRYPTION_KEY  # Generate with: openssl rand -hex 32
 
 # Create KV namespace
-wrangler kv:namespace create "OAUTH_KV"
+wrangler kv namespace create "OAUTH_KV"
 ```
 
 #### Step 3: Update Configuration File

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ wrangler secret put FEISHU_APP_SECRET
 wrangler secret put COOKIE_ENCRYPTION_KEY  # 使用 openssl rand -hex 32 生成
 
 # 创建 KV 命名空间
-wrangler kv:namespace create "OAUTH_KV"
+wrangler kv namespace create "OAUTH_KV"
 ```
 
 #### 步骤 3: 更新配置文件


### PR DESCRIPTION
## Summary\n- 将 README.md 和 README.en.md 中的 `wrangler kv:namespace create \"OAUTH_KV\"` 更新为 `wrangler kv namespace create \"OAUTH_KV\"`，适配 Wrangler v3+ 命令格式\n\nFixes #35\n\n## Test plan\n- [ ] 验证 `wrangler kv namespace create \"OAUTH_KV\"` 在 Wrangler v3+ 中可正常执行\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)