### PR TITLE
chore: 添加 .mcp.json 到 .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,4 @@ reports/
 .kiro/
 .devcontainer/
 .claude/
+.mcp.json


### PR DESCRIPTION
## Summary
- 添加 `.mcp.json` 到 .gitignore，避免 MCP 配置文件被提交到仓库

## Test plan
- [x] 确认 `.mcp.json` 不会被 git 追踪

🤖 Generated with [Claude Code](https://claude.com/claude-code)